### PR TITLE
Fix memory retrieval and endpoint logic

### DIFF
--- a/core/memory.py
+++ b/core/memory.py
@@ -130,16 +130,18 @@ class Tier1ActiveMemory:
     def get_tokens(self, start: int, end: int) -> np.ndarray:
         """Retrieve tokens from active memory."""
         with self.lock:
-            if start >= self.total_tokens or end > self.total_tokens:
-                raise ValueError(f"Invalid token range: {start}-{end}, total: {self.total_tokens}")
-            
-            # Simple retrieval from stored chunks
+            if start < 0 or end < 0 or start >= end or end > self.total_tokens:
+                raise ValueError(
+                    f"Invalid token range: {start}-{end}, total: {self.total_tokens}"
+                )
+
+            # Collect tokens until we've covered the requested end position
             result = []
             for chunk in self.chunks:
-                if len(result) >= end - start:
+                if len(result) >= end:
                     break
                 result.extend(chunk.tokens)
-            
+
             # Return the requested range
             return np.array(result[start:end], dtype=np.int32)
     

--- a/reasoning/temporal.py
+++ b/reasoning/temporal.py
@@ -362,7 +362,9 @@ class EventSequenceModeling:
         # Count subsequences
         subsequence_counts = defaultdict(int)
         for sequence in self.sequences:
-            for length in range(2, min(len(sequence) + 1, 6)):  # Look for patterns of length 2-5
+            # Look for patterns of length 2-5 inclusive
+            max_len = min(len(sequence), 5)
+            for length in range(2, max_len + 1):
                 for i in range(len(sequence) - length + 1):
                     subsequence = tuple(sequence[i:i+length])
                     subsequence_counts[subsequence] += 1


### PR DESCRIPTION
## Summary
- Correct memory retrieval range handling in `Tier1ActiveMemory.get_tokens`
- Align tokenization endpoint with `TokenizationResult` structure
- Use router output properly in reasoning endpoint and tighten pattern search ranges

## Testing
- `pytest tests/unit/test_causal.py`
- `pytest tests/test_router.py`
- `pytest tests/unit/test_engine.py`
- `pytest tests/unit/test_memory.py` *(fails: ModuleNotFoundError: No module named 'core')*
- `pytest tests/unit/test_temporal.py` *(fails: ModuleNotFoundError: No module named 'reasoning')*


------
https://chatgpt.com/codex/tasks/task_e_68904962d2fc832db640e750cce64072